### PR TITLE
Disable velocity filter

### DIFF
--- a/src/CLaserOdometry2D.cpp
+++ b/src/CLaserOdometry2D.cpp
@@ -825,41 +825,44 @@ bool CLaserOdometry2D::filterLevelSolution()
 
   assert((kai_loc_level_).isApprox(Bii*kai_b, 1e-5) && "Ax=b has no solution." && __LINE__);
 
-  //Second, we have to describe both the old linear and angular speeds in the "eigenvector" basis too
-  //-------------------------------------------------------------------------------------------------
-  MatrixS31 kai_loc_sub;
+  // //Second, we have to describe both the old linear and angular speeds in the "eigenvector" basis too
+  // //-------------------------------------------------------------------------------------------------
+  // MatrixS31 kai_loc_sub;
 
-  //Important: we have to substract the solutions from previous levels
-  Eigen::Matrix3f acu_trans;
-  acu_trans.setIdentity();
-  for (unsigned int i=0; i<level; i++)
-    acu_trans = transformations[i]*acu_trans;
+  // //Important: we have to substract the solutions from previous levels
+  // Eigen::Matrix3f acu_trans;
+  // acu_trans.setIdentity();
+  // for (unsigned int i=0; i<level; i++)
+  //   acu_trans = transformations[i]*acu_trans;
 
-  kai_loc_sub(0) = -fps*acu_trans(0,2);
-  kai_loc_sub(1) = -fps*acu_trans(1,2);
-  if (acu_trans(0,0) > 1.f)
-    kai_loc_sub(2) = 0.f;
-  else
-  {
-    kai_loc_sub(2) = -fps*std::acos(acu_trans(0,0))*rf2o::sign(acu_trans(1,0));
-  }
-  kai_loc_sub += kai_loc_old_;
+  // kai_loc_sub(0) = -fps*acu_trans(0,2);
+  // kai_loc_sub(1) = -fps*acu_trans(1,2);
+  // if (acu_trans(0,0) > 1.f)
+  //   kai_loc_sub(2) = 0.f;
+  // else
+  // {
+  //   kai_loc_sub(2) = -fps*std::acos(acu_trans(0,0))*rf2o::sign(acu_trans(1,0));
+  // }
+  // kai_loc_sub += kai_loc_old_;
 
-  Eigen::Matrix<float,3,1> kai_b_old;
-  kai_b_old = Bii.colPivHouseholderQr().solve(kai_loc_sub);
+  // Eigen::Matrix<float,3,1> kai_b_old;
+  // kai_b_old = Bii.colPivHouseholderQr().solve(kai_loc_sub);
 
-  assert((kai_loc_sub).isApprox(Bii*kai_b_old, 1e-5) && "Ax=b has no solution." && __LINE__);
+  // assert((kai_loc_sub).isApprox(Bii*kai_b_old, 1e-5) && "Ax=b has no solution." && __LINE__);
 
-  //Filter speed
-  const float cf = 15e3f*std::exp(-float(int(level))),
-              df = 0.05f*std::exp(-float(int(level)));
+  // //Filter speed
+  // const float cf = 15e3f*std::exp(-float(int(level))),
+  //             df = 0.05f*std::exp(-float(int(level)));
 
-  Eigen::Matrix<float,3,1> kai_b_fil;
-  for (unsigned int i=0; i<3; i++)
-  {
-    kai_b_fil(i) = (kai_b(i) + (cf*eigensolver.eigenvalues()(i,0) + df)*kai_b_old(i))/(1.f + cf*eigensolver.eigenvalues()(i,0) + df);
-    //kai_b_fil_f(i,0) = (1.f*kai_b(i,0) + 0.f*kai_b_old_f(i,0))/(1.0f + 0.f);
-  }
+  // Eigen::Matrix<float,3,1> kai_b_fil;
+  // for (unsigned int i=0; i<3; i++)
+  // {
+  //   kai_b_fil(i) = (kai_b(i) + (cf*eigensolver.eigenvalues()(i,0) + df)*kai_b_old(i))/(1.f + cf*eigensolver.eigenvalues()(i,0) + df);
+  //   //kai_b_fil_f(i,0) = (1.f*kai_b(i,0) + 0.f*kai_b_old_f(i,0))/(1.0f + 0.f);
+  // }
+
+  // Unfiltered
+  Eigen::Matrix<float,3,1> kai_b_fil = kai_b;
 
   //Transform filtered speed to local reference frame and compute transformation
   Eigen::Matrix<float, 3, 1> kai_loc_fil = Bii.inverse().colPivHouseholderQr().solve(kai_b_fil);

--- a/src/CLaserOdometry2D.cpp
+++ b/src/CLaserOdometry2D.cpp
@@ -861,7 +861,7 @@ bool CLaserOdometry2D::filterLevelSolution()
   //   //kai_b_fil_f(i,0) = (1.f*kai_b(i,0) + 0.f*kai_b_old_f(i,0))/(1.0f + 0.f);
   // }
 
-  // Unfiltered
+  // Disable the velocity fitler (commented code above) and output unfiltered velocities:
   Eigen::Matrix<float,3,1> kai_b_fil = kai_b;
 
   //Transform filtered speed to local reference frame and compute transformation


### PR DESCRIPTION
I think the idea here was to smooth the velocity and to consider the old linear and angular speeds, too, but for sensor fusion with other sensors we prefer an unfiltered scan matching result. Without that patch the velocity slowly decreases in corridors without many features to learn about the forward speed. Both may be wrong and not reflect the actual velocity.