### PR TITLE
Fix NaN pose after one failed odometry update

### DIFF
--- a/include/rf2o_laser_odometry/CLaserOdometry2D.h
+++ b/include/rf2o_laser_odometry/CLaserOdometry2D.h
@@ -152,7 +152,6 @@ protected:
   Pose3d laser_pose_on_robot_;
   Pose3d laser_pose_on_robot_inv_;
   Pose3d laser_pose_;
-  Pose3d laser_oldpose_;
   Pose3d robot_pose_;
   Pose3d robot_oldpose_;
 

--- a/src/CLaserOdometry2D.cpp
+++ b/src/CLaserOdometry2D.cpp
@@ -31,7 +31,6 @@ CLaserOdometry2D::CLaserOdometry2D() :
   laser_pose_on_robot_(Pose3d::Identity()),
   laser_pose_on_robot_inv_(Pose3d::Identity()),
   laser_pose_(Pose3d::Identity()),
-  laser_oldpose_(Pose3d::Identity()),
   robot_pose_(Pose3d::Identity()),
   robot_oldpose_(Pose3d::Identity())
 {
@@ -86,7 +85,6 @@ void CLaserOdometry2D::init(const sensor_msgs::LaserScan& scan,
 
   //Set the initial pose
   laser_pose_    = robot_initial_pose * laser_pose_on_robot_;
-  laser_oldpose_ = laser_pose_;
 
   // Init module (internal)
   //------------------------
@@ -730,7 +728,6 @@ void CLaserOdometry2D::Reset(const Pose3d& ini_pose/*, CObservation2DRangeScan s
 {
   //Set the initial pose
   laser_pose_    = ini_pose;
-  laser_oldpose_ = ini_pose;
 
   //readLaser(scan);
   createImagePyramid();
@@ -929,7 +926,6 @@ void CLaserOdometry2D::PoseUpdate()
 
   //						Update poses
   //-------------------------------------------------------
-  laser_oldpose_ = laser_pose_;
 
   //  Eigen::Matrix3f aux_acu = acu_trans;
   Pose3d pose_aux_2D = Pose3d::Identity();

--- a/src/CLaserOdometry2D.cpp
+++ b/src/CLaserOdometry2D.cpp
@@ -86,7 +86,7 @@ void CLaserOdometry2D::init(const sensor_msgs::LaserScan& scan,
 
   //Set the initial pose
   laser_pose_    = robot_initial_pose * laser_pose_on_robot_;
-  laser_oldpose_ = laser_oldpose_;
+  laser_oldpose_ = laser_pose_;
 
   // Init module (internal)
   //------------------------
@@ -938,7 +938,15 @@ void CLaserOdometry2D::PoseUpdate()
   pose_aux_2D.translation()(0) = acu_trans(0,2);
   pose_aux_2D.translation()(1) = acu_trans(1,2);
 
+#ifdef DISABLE_VELOCITY_FILTER
+  // Skip integration if scan matching failed and acu_trans, kai_loc_
+  // and kai_abs_ have NaN values
+  if (pose_aux_2D.matrix().array().isFinite().all()) {
+    laser_pose_ = laser_pose_ * pose_aux_2D;
+  }
+#else
   laser_pose_ = laser_pose_ * pose_aux_2D;
+#endif
 
   last_increment_ = pose_aux_2D;
 


### PR DESCRIPTION
Partially addresses https://intermodalics.slack.com/archives/C5E8LUFD5/p1622124518020100?thread_ts=1622124198.019800&cid=C5E8LUFD5. With the velocity filter disabled (#1 and #2) the delta pose can have NaN values, which invalidates the integrated `laser_pose_` and `laser_oldpose_`.